### PR TITLE
Boardクラスにselect()メソッドを追加する

### DIFF
--- a/Board.pde
+++ b/Board.pde
@@ -17,3 +17,11 @@ class Board {
     iArea.draw();
   }
 }
+ void select(int x, int y){
+    AbstractKoma koma = komaList.getSelectedKoma();
+    if(koma==null){
+      komaList.select(x,y);
+    }else{
+      koma.kStat.selected=false;
+    }
+  }


### PR DESCRIPTION
select()メソッドでは，KomaListクラスのインスタンスkomaListのgetSelectedKoma()メソッドを利用して，既に選択されているコマ（ある場合）を取得する．選択済みのコマがない場合は座標(x,y)に存在するそのターン(Left/Right)に属するコマを選択するため，komaListのselect(x,y)を呼び出す．ある場合は選択済みのコマの選択状態を解除する． つまり，何か選択されたコマがあれば，どこをクリックしても選択状態が解除される．